### PR TITLE
Remove unused languages from config

### DIFF
--- a/src/app/config-sample.php
+++ b/src/app/config-sample.php
@@ -36,17 +36,9 @@ $cfg = [
     'i18n' => [
         'locales' => [
             'en_IN',
-            'hi_IN',
-            'te_IN',
-            'gu_IN',
-            'mr_IN'
         ],
         'languages' => [
             'en' => 'en_IN',
-            'hi' => 'hi_IN',
-            'te' => 'te_IN',
-            'gu' => 'gu_IN',
-            'mr' => 'mr_IN'
         ],
         // 'gettext' => false,
         'gettext' => [


### PR DESCRIPTION
This will remove non-existent language pages from the HTML
and will also 404 on requests to /<lang>.